### PR TITLE
Add tmp for debug log

### DIFF
--- a/sda-svc/templates/finalize-deploy.yaml
+++ b/sda-svc/templates/finalize-deploy.yaml
@@ -91,9 +91,18 @@ spec:
 {{ toYaml .Values.finalize.resources | trim | indent 10 }}
     {{- if not .Values.global.pkiService }}
         volumeMounts:
+        {{- if (.Values.global.log | lower) eq "debug" }}
+        - name: tmp
+          mountPath: /tmp
+        {{- end }}
         - name: tls
           mountPath: {{ template "tlsPath" . }}
       volumes:
+      {{- if (.Values.global.log | lower) eq "debug" }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+      {{- end }}
         - name: {{ ternary "tls" "tls-certs" (empty .Values.global.pkiPermissions) }}
           secret:
             defaultMode: 0440

--- a/sda-svc/templates/ingest-deploy.yaml
+++ b/sda-svc/templates/ingest-deploy.yaml
@@ -144,6 +144,10 @@ spec:
         resources:
 {{ toYaml .Values.ingest.resources | trim | indent 10 }}
         volumeMounts:
+      {{- if (.Values.global.log | lower) eq "debug" }}
+        - name: tmp
+          mountPath: /tmp
+      {{- end }}
       {{- if not .Values.global.pkiService }}
         - name: tls
           mountPath: "{{ template "tlsPath" . }}"
@@ -157,6 +161,11 @@ spec:
           mountPath: {{ .Values.global.inbox.path | quote }}
       {{- end }}
       volumes:
+    {{- if (.Values.global.log | lower) eq "debug" }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+    {{- end }}
     {{- if not .Values.global.pkiService }}
         - name: {{ ternary "tls" "tls-certs" (empty .Values.global.pkiPermissions) }}
           secret:

--- a/sda-svc/templates/verify-deploy.yaml
+++ b/sda-svc/templates/verify-deploy.yaml
@@ -125,6 +125,10 @@ spec:
         resources:
 {{ toYaml .Values.verify.resources | trim | indent 10 }}
         volumeMounts:
+        {{- if (.Values.global.log | lower) eq "debug" }}
+        - name: tmp
+          mountPath: /tmp
+        {{- end }}
         {{- if not .Values.global.confFile }}
         - name: c4gh
           mountPath: {{ template "c4ghPath" . }}
@@ -138,6 +142,11 @@ spec:
           mountPath: {{ .Values.global.archive.volumePath | quote }}
         {{- end }}
       volumes:
+    {{- if (.Values.global.log | lower) eq "debug" }}
+        - name: tmp
+          emptyDir:
+            medium: Memory
+    {{- end }}
     {{- if not .Values.global.pkiService }}
         - name: {{ ternary "tls" "tls-certs" (empty .Values.global.pkiPermissions) }}
           secret:


### PR DESCRIPTION
Finalize, ingest and verify require a tmp folder for debug log and this configuration was missing.