### PR TITLE
Update mq network policy

### DIFF
--- a/sda-mq/templates/networkpolicies.yaml
+++ b/sda-mq/templates/networkpolicies.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny-all
+  name: deny-ingress-other-namespaces
   namespace: {{ .Release.Namespace }}
   spec:
     ingress:

--- a/sda-mq/templates/networkpolicies.yaml
+++ b/sda-mq/templates/networkpolicies.yaml
@@ -4,29 +4,13 @@ kind: NetworkPolicy
 metadata:
   name: default-deny-all
   namespace: {{ .Release.Namespace }}
-spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-dns-access
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector: {}
-  policyTypes:
-  - Egress
-  egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kube-system: networkpolicy
-    ports:
-    - protocol: UDP
-      port: 53
+  spec:
+    ingress:
+    - from:
+      - podSelector: {}
+    podSelector: {}
+    policyTypes:
+    - Ingress
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
 - Deny ingress traffic from other namespaces
 - Except selected pods at sda-internal and sda-external

Signed-off-by: Valtteri Valtia <valtteri.valtia@csc.fi>